### PR TITLE
feat(EP-10509): Include `ffprobe` into the lambda layer. Update runtimes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build/layer/bin/ffmpeg:
 	mkdir -p build/layer/bin
 	rm -rf build/ffmpeg*
 	cd build && curl https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | tar x
-	mv build/ffmpeg*/ffmpeg build/layer/bin
+	mv build/ffmpeg*/ffmpeg build/ffmpeg*/ffprobe build/layer/bin
 
 build/output.yaml: template.yaml build/layer/bin/ffmpeg
 	aws cloudformation package --template $< --s3-bucket $(DEPLOYMENT_BUCKET) --output-template-file $@

--- a/README-SAR.md
+++ b/README-SAR.md
@@ -4,7 +4,7 @@ Static build of FFmpeg/FFprobe for Amazon Linux 2, packaged as a Lambda layer. B
 
 This application provides a single output, `LayerVersion`, which points to a
 Lambda Layer ARN you can use with Lambda runtimes based on Amazon Linux 2 (such
-as the `nodejs10.x` runtime).
+as the `nodejs20.x` runtime).
 
 For an example of how to use the layer, check out 
 <https://github.com/serverlesspub/ffmpeg-aws-lambda-layer/tree/master/example>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FFmpeg/FFprobe for AWS Lambda
 
-A Lambda layer containing a static version of FFmpeg/FFprobe utilities from the [`FFmpeg`](https://www.ffmpeg.org/) Linux package, compatible with Amazon Linux 2.x and Amazon Linux 1.x instances (including the `nodejs10.x` runtime, and the updated 2018.03 Amazon Linux 1 runtimes). 
+A Lambda layer containing a static version of FFmpeg/FFprobe utilities from the [`FFmpeg`](https://www.ffmpeg.org/) Linux package, compatible with Amazon Linux 2.x and Amazon Linux 1.x instances (including the `nodejs20.x` runtime, and the updated 2018.03 Amazon Linux 1 runtimes). 
 
 ## Usage
 

--- a/example/template-sar.yaml
+++ b/example/template-sar.yaml
@@ -38,7 +38,7 @@ Resources:
       Handler: index.handler
       Timeout: 180
       MemorySize: 1024
-      Runtime: nodejs10.x
+      Runtime: nodejs20.x
       CodeUri: src
       Layers:
         - !GetAtt ffmpeglambdalayer.Outputs.LayerVersion

--- a/example/template.yaml
+++ b/example/template.yaml
@@ -29,7 +29,7 @@ Resources:
       Handler: index.handler
       Timeout: 180
       MemorySize: 1024
-      Runtime: nodejs10.x
+      Runtime: nodejs20.x
       CodeUri: src
       Layers:
         - !Ref LambdaLayer

--- a/template.yaml
+++ b/template.yaml
@@ -13,11 +13,7 @@ Resources:
       Description: FFMPEG for AWS Lambda
       ContentUri: build/layer
       CompatibleRuntimes:
-        - nodejs10.x
-        - python3.6
-        - ruby2.5
-        - java8
-        - go1.x
+        - nodejs20.x
       LicenseInfo: GPL-2.0-or-later
       RetentionPolicy: Retain
 


### PR DESCRIPTION
## Ticket
Link to ticket: https://q4websystems.atlassian.net/browse/EP-10509

## Description
feat(EP-10509): Include ffprobe into the lambda layer. Update runtimes.

<img width="1691" alt="Screenshot 2024-06-05 at 15 04 05" src="https://github.com/serverlesspub/ffmpeg-aws-lambda-layer/assets/93537841/62cc18d7-88c3-4ed6-b2ad-65f3110a9a45">
